### PR TITLE
Add new Pester tests for file moves and terminal utilities

### DIFF
--- a/Scripts/Tests/Launcher-PesterTests.ps1
+++ b/Scripts/Tests/Launcher-PesterTests.ps1
@@ -28,7 +28,16 @@ $test5 = "$Global:PSRoot\Scripts\Tests\Test-NewItemNameWithDate.Tests.ps1"
 $test6 = "$Global:PSRoot\Scripts\Tests\Test-CompareEquals.Tests.ps1"
 $test7 = "$Global:PSRoot\Scripts\Tests\Test-CallStack.Tests.ps1"
 $test8 = "$Global:PSRoot\Scripts\Tests\Test-GetOutlookItemType.Tests.ps1"
-$test9 = "$Global:PSRoot\Scripts\Tests\TEst-DateTimeUtils.Tests.ps1"
+$test9 = "$Global:PSRoot\Scripts\Tests\Test-DateTimeUtils.Tests.ps1"
+$test10 = "$Global:PSRoot\Scripts\Tests\Test-Select-Files.Tests.ps1"
+$test11 = "$Global:PSRoot\Scripts\Tests\Test-Get-PaddedText.Tests.ps1"
+$test12 = "$Global:PSRoot\Scripts\Tests\Test-Move-Files.Tests.ps1"
+$test13 = "$Global:PSRoot\Scripts\Tests\Test-Rename-Files.Tests.ps1"
+$test14 = "$Global:PSRoot\Scripts\Tests\Test-Rename-FileExtension.Tests.ps1"
+$test15 = "$Global:PSRoot\Scripts\Tests\Test-SetDir-BaseDirsUtils.Tests.ps1"
+$test16 = "$Global:PSRoot\Scripts\Tests\Test-SetDir-KeywordDirsUtils.Tests.ps1"
+$test17 = "$Global:PSRoot\Scripts\Tests\Test-Set-Dir.Tests.ps1"
+$test18 = "$Global:PSRoot\Scripts\Tests\Test-Register-GoDirCompleter.Tests.ps1"
 
 # Optional breakpoints
 # Set-PSBreakpoint -Script "$PSScriptRoot\..\DevUtils\Compare-Utils.ps1" -Line 25
@@ -37,7 +46,10 @@ $test9 = "$Global:PSRoot\Scripts\Tests\TEst-DateTimeUtils.Tests.ps1"
 #Set-PSBreakpoint -Command '&'
 
 $conf = [PesterConfiguration]::Default
-$conf.Run.Path = @($test1, $test2, $test3, $test4, $test5, $test6, $test7, $test8, $test9)
+$conf.Run.Path = @(
+    $test1, $test2, $test3, $test4, $test5, $test6, $test7, $test8, $test9,
+    $test10, $test11, $test12, $test13, $test14, $test15, $test16, $test17, $test18
+)
 #$conf.Run.Path = @($test1, $test2, $test3, $test4, $test5, $test6)
 #$conf.Run.Path = @($test4, $test6)
 #$conf.Run.Path = @($test1)

--- a/Scripts/Tests/Test-Get-PaddedText.Tests.ps1
+++ b/Scripts/Tests/Test-Get-PaddedText.Tests.ps1
@@ -1,0 +1,24 @@
+. "$PSScriptRoot/../Initialize-CoreConfig.ps1"
+. "$PSScriptRoot/../DevUtils/Format-Utils.ps1"
+
+Describe 'Get-PaddedText' {
+    It 'left aligns text when width is sufficient' {
+        Get-PaddedText -Text 'abc' -Width 6 -Align 'left' | Should -Be 'abc   '
+    }
+
+    It 'center aligns text when width is sufficient' {
+        Get-PaddedText -Text 'abc' -Width 7 -Align 'center' | Should -Be '  abc  '
+    }
+
+    It 'right aligns text when width is sufficient' {
+        Get-PaddedText -Text 'abc' -Width 5 -Align 'right' | Should -Be '  abc'
+    }
+
+    It 'uses minimum width when width too small' {
+        Get-PaddedText -Text 'abc' -Width 2 -Align 'left' | Should -Be 'abc  '
+    }
+
+    It 'truncates text that exceeds width' {
+        Get-PaddedText -Text 'abcdefghij' -Width 5 -Align 'left' | Should -Be 'a...j'
+    }
+}

--- a/Scripts/Tests/Test-Move-Files.Tests.ps1
+++ b/Scripts/Tests/Test-Move-Files.Tests.ps1
@@ -1,0 +1,31 @@
+. "$PSScriptRoot/../Initialize-CoreConfig.ps1"
+. "$PSScriptRoot/../FileUtils/Move-Files.ps1"
+
+Describe 'Move-Files' {
+    BeforeAll {
+        $script:Src = Join-Path $env:TEMP "MoveFilesSrc_$((Get-Random))"
+        $script:Dst = Join-Path $env:TEMP "MoveFilesDst_$((Get-Random))"
+        New-Item -ItemType Directory -Path $script:Src -Force | Out-Null
+        New-Item -ItemType Directory -Path $script:Dst -Force | Out-Null
+    }
+
+    AfterAll {
+        Remove-Item -Path $script:Src -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path $script:Dst -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'moves matching files to destination' {
+        $file = New-Item -ItemType File -Path (Join-Path $script:Src 'foo.txt') -Force
+        Move-Files -srcDir $script:Src -dstDir $script:Dst -filePattern 'foo' -TOTAL_TIMEOUT 1 -DELAY_SECONDS 0
+        Test-Path (Join-Path $script:Dst $file.Name) | Should -BeTrue
+        Test-Path $file.FullName | Should -BeFalse
+    }
+
+    It 'respects DryRun switch' {
+        $file = New-Item -ItemType File -Path (Join-Path $script:Src 'bar.txt') -Force
+        Move-Files -srcDir $script:Src -dstDir $script:Dst -filePattern 'bar' -DryRun -TOTAL_TIMEOUT 1 -DELAY_SECONDS 0
+        Test-Path $file.FullName | Should -BeTrue
+        Test-Path (Join-Path $script:Dst $file.Name) | Should -BeFalse
+        Remove-Item $file.FullName -Force
+    }
+}

--- a/Scripts/Tests/Test-Register-GoDirCompleter.Tests.ps1
+++ b/Scripts/Tests/Test-Register-GoDirCompleter.Tests.ps1
@@ -1,0 +1,10 @@
+. "$PSScriptRoot/../Initialize-CoreConfig.ps1"
+. "$PSScriptRoot/../TerminalUtils/Register-GoDirCompleter.ps1"
+
+Describe 'Register-GoDirCompleter' {
+    It 'registers argument completer for godir' {
+        Mock Register-ArgumentCompleter {}
+        . "$PSScriptRoot/../TerminalUtils/Register-GoDirCompleter.ps1"
+        Assert-MockCalled Register-ArgumentCompleter -Times 1
+    }
+}

--- a/Scripts/Tests/Test-Rename-FileExtension.Tests.ps1
+++ b/Scripts/Tests/Test-Rename-FileExtension.Tests.ps1
@@ -1,0 +1,28 @@
+. "$PSScriptRoot/../Initialize-CoreConfig.ps1"
+. "$PSScriptRoot/../FileUtils/Rename-FileExtension.ps1"
+
+Describe 'Rename-FileExtension' {
+    BeforeAll {
+        $script:Dir = Join-Path $env:TEMP "RenameExt_$((Get-Random))"
+        New-Item -ItemType Directory -Path $script:Dir -Force | Out-Null
+    }
+
+    AfterAll {
+        Remove-Item -Path $script:Dir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'renames file extensions' {
+        $file = New-Item -ItemType File -Path (Join-Path $script:Dir 'a.txt') -Force
+        Rename-FileExtension -OldExt 'txt' -NewExt 'log' -Dir $script:Dir
+        Test-Path (Join-Path $script:Dir 'a.log') | Should -BeTrue
+        Test-Path $file.FullName | Should -BeFalse
+    }
+
+    It 'performs dry run when -DryRun used' {
+        $file = New-Item -ItemType File -Path (Join-Path $script:Dir 'b.txt') -Force
+        Rename-FileExtension -OldExt 'txt' -NewExt 'log' -Dir $script:Dir -DryRun
+        Test-Path $file.FullName | Should -BeTrue
+        Test-Path (Join-Path $script:Dir 'b.log') | Should -BeFalse
+        Remove-Item $file.FullName -Force
+    }
+}

--- a/Scripts/Tests/Test-Rename-Files.Tests.ps1
+++ b/Scripts/Tests/Test-Rename-Files.Tests.ps1
@@ -1,0 +1,68 @@
+. "$PSScriptRoot/../Initialize-CoreConfig.ps1"
+. "$PSScriptRoot/../FileUtils/Rename-Files.ps1"
+
+Describe 'Get-FilteredFiles' {
+    BeforeAll {
+        $script:Dir = Join-Path $env:TEMP "Filtered_$((Get-Random))"
+        $sub = Join-Path $script:Dir 'sub'
+        New-Item -ItemType Directory -Path $script:Dir -Force | Out-Null
+        New-Item -ItemType Directory -Path $sub -Force | Out-Null
+        New-Item -ItemType File -Path (Join-Path $script:Dir 'a.txt') -Force | Out-Null
+        New-Item -ItemType File -Path (Join-Path $sub 'b.csv') -Force | Out-Null
+        New-Item -ItemType File -Path (Join-Path $script:Dir 'report.txt') -Force | Out-Null
+    }
+
+    AfterAll {
+        Remove-Item -Path $script:Dir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'filters by extension and substring' {
+        $files = Get-FilteredFiles -Path $script:Dir -Extension '.txt' -Substring 'report' -Recurse
+        $files.Name | Should -Be @('report.txt')
+    }
+}
+
+Describe 'New-UniqueFilename' {
+    BeforeAll {
+        $script:Dst = Join-Path $env:TEMP "Unique_$((Get-Random))"
+        New-Item -ItemType Directory -Path $script:Dst -Force | Out-Null
+        New-Item -ItemType File -Path (Join-Path $script:Dst 'Base_20230101.txt') -Force | Out-Null
+    }
+
+    AfterAll {
+        Remove-Item -Path $script:Dst -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'generates a unique path when file exists' {
+        $result = New-UniqueFilename -BaseName 'Base' -Extension '.txt' -CreationDate '20230101' -SequenceByDate:$false -DestPath $script:Dst -SrcPath $script:Dst
+        Split-Path $result -Leaf | Should -Be 'Base_20230101_1.txt'
+    }
+}
+
+Describe 'ConvertTo_SantizedName' {
+    It 'replaces invalid characters with underscores' {
+        ConvertTo_SantizedName -Name 'Inv<name>.txt' | Should -Be 'Inv_name_.txt'
+    }
+}
+
+Describe 'Rename-And-MoveFiles' {
+    BeforeAll {
+        $script:Src = Join-Path $env:TEMP "RenameSrc_$((Get-Random))"
+        $script:Dst = Join-Path $env:TEMP "RenameDst_$((Get-Random))"
+        New-Item -ItemType Directory -Path $script:Src -Force | Out-Null
+        New-Item -ItemType Directory -Path $script:Dst -Force | Out-Null
+        $file = New-Item -ItemType File -Path (Join-Path $script:Src 'orig.csv') -Force
+        (Get-Item $file.FullName).CreationTime = [datetime]'2023-01-01'
+    }
+
+    AfterAll {
+        Remove-Item -Path $script:Src -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path $script:Dst -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'renames and moves files' {
+        Rename-And-MoveFiles -SrcPath $script:Src -DestPath $script:Dst -BaseName 'MyBase' -FilterByExtension '.csv'
+        Test-Path (Join-Path $script:Dst 'MyBase_20230101.csv') | Should -BeTrue
+        (Get-ChildItem -Path $script:Src).Count | Should -Be 0
+    }
+}

--- a/Scripts/Tests/Test-Select-Files.Tests.ps1
+++ b/Scripts/Tests/Test-Select-Files.Tests.ps1
@@ -1,0 +1,37 @@
+. "$PSScriptRoot/../Initialize-CoreConfig.ps1"
+. "$PSScriptRoot/../FileUtils/Select-Files.ps1"
+
+Describe 'Select-Files' {
+    BeforeAll {
+        $script:TestDir = Join-Path $env:TEMP "SelectFilesTest_$((Get-Random))"
+        $null = New-Item -ItemType Directory -Path $script:TestDir -Force
+        $null = New-Item -ItemType File -Path (Join-Path $script:TestDir 'file1.txt') -Force
+        $null = New-Item -ItemType File -Path (Join-Path $script:TestDir 'file2.csv') -Force
+        $null = New-Item -ItemType File -Path (Join-Path $script:TestDir 'report.txt') -Force
+        $sub = Join-Path $script:TestDir 'Sub'
+        $null = New-Item -ItemType Directory -Path $sub -Force
+        $null = New-Item -ItemType File -Path (Join-Path $sub 'file3.txt') -Force
+    }
+
+    AfterAll {
+        Remove-Item -Path $script:TestDir -Recurse -Force
+    }
+
+    It 'filters by extension' {
+        $result = Select-Files -Dir $script:TestDir -Ext '.txt' -Recurse | Select-Object -ExpandProperty Name
+        $result | Should -Contain 'file1.txt'
+        $result | Should -Contain 'report.txt'
+        $result | Should -Contain 'file3.txt'
+        $result | Should -Not -Contain 'file2.csv'
+    }
+
+    It 'filters by substring' {
+        $result = Select-Files -Dir $script:TestDir -SubStr 'report' | Select-Object -ExpandProperty Name
+        $result | Should -Be @('report.txt')
+    }
+
+    It 'recurses into subdirectories with -Recurse' {
+        $result = Select-Files -Dir $script:TestDir -Ext '.txt' -Recurse | Select-Object -ExpandProperty Name
+        $result | Should -Contain 'file3.txt'
+    }
+}

--- a/Scripts/Tests/Test-Set-Dir.Tests.ps1
+++ b/Scripts/Tests/Test-Set-Dir.Tests.ps1
@@ -1,0 +1,30 @@
+. "$PSScriptRoot/../Initialize-CoreConfig.ps1"
+. "$PSScriptRoot/../TerminalUtils/Set-Dir.ps1"
+
+Describe 'Set-Dir' {
+    BeforeAll {
+        $script:Target = Join-Path $env:TEMP "GoDir_$((Get-Random))"
+        New-Item -ItemType Directory -Path $script:Target -Force | Out-Null
+        $global:KeywordDirs = @{ test = $script:Target }
+        $global:BaseDirs = @($env:TEMP)
+    }
+
+    AfterAll {
+        Remove-Item -Path $script:Target -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'navigates to keyword directory' {
+        Mock Set-Location {}
+        Set-Dir -Keyword 'test'
+        Assert-MockCalled Set-Location -ParameterFilter { $Path -eq $script:Target } -Times 1
+    }
+
+    It 'falls back to base dirs when keyword missing' {
+        $dir = Join-Path $env:TEMP 'fallback'
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+        Mock Set-Location {}
+        Set-Dir -Keyword (Split-Path -Leaf $dir)
+        Assert-MockCalled Set-Location -ParameterFilter { $Path -eq $dir } -Times 1
+        Remove-Item $dir -Recurse -Force
+    }
+}

--- a/Scripts/Tests/Test-SetDir-BaseDirsUtils.Tests.ps1
+++ b/Scripts/Tests/Test-SetDir-BaseDirsUtils.Tests.ps1
@@ -1,0 +1,29 @@
+. "$PSScriptRoot/../Initialize-CoreConfig.ps1"
+. "$PSScriptRoot/../TerminalUtils/SetDir-BaseDirsUtils.ps1"
+
+Describe 'SetDir-BaseDirsUtils' {
+    It 'sets and gets the base dirs file path' {
+        Set-BaseDirsFile 'test.psd1'
+        Get-BaseDirsFile | Should -Be 'test.psd1'
+    }
+
+    It 'publishes base dirs from file' {
+        $tmp = Join-Path $env:TEMP "baseDirs_$((Get-Random)).psd1"
+        "@('A','B')" | Set-Content -Path $tmp -Encoding UTF8
+        Set-BaseDirsFile $tmp
+        Publish-BaseDirs
+        $global:BaseDirs | Should -Contain 'A'
+        $global:BaseDirs | Should -Contain 'B'
+        Remove-Item $tmp -Force
+    }
+
+    It 'adds new base dir via Edit-BaseDirs' {
+        $tmp = Join-Path $env:TEMP "baseDirs_$((Get-Random)).psd1"
+        "@('A')" | Set-Content -Path $tmp -Encoding UTF8
+        Set-BaseDirsFile $tmp
+        Publish-BaseDirs
+        Edit-BaseDirs -Add 'B'
+        $global:BaseDirs | Should -Contain 'B'
+        Remove-Item $tmp -Force
+    }
+}

--- a/Scripts/Tests/Test-SetDir-KeywordDirsUtils.Tests.ps1
+++ b/Scripts/Tests/Test-SetDir-KeywordDirsUtils.Tests.ps1
@@ -1,0 +1,29 @@
+. "$PSScriptRoot/../Initialize-CoreConfig.ps1"
+. "$PSScriptRoot/../TerminalUtils/SetDir-KeywordDirsUtils.ps1"
+
+Describe 'SetDir-KeywordDirsUtils' {
+    It 'sets and gets keyword dirs file path' {
+        Set-BKeywordDirsFile 'k.psd1'
+        Get-KeywordDirsFile | Should -Be 'k.psd1'
+    }
+
+    It 'publishes keyword dirs from file' {
+        $tmp = Join-Path $env:TEMP "keywordDirs_$((Get-Random)).psd1"
+        "@{ a = 'A'; b = 'B' }" | Set-Content -Path $tmp -Encoding UTF8
+        Set-BKeywordDirsFile $tmp
+        Publish-KeywordDirs
+        $global:KeywordDirs.Keys | Should -Contain 'a'
+        $global:KeywordDirs['a'] | Should -Be 'A'
+        Remove-Item $tmp -Force
+    }
+
+    It 'adds new keyword via Edit-KeywordDirs' {
+        $tmp = Join-Path $env:TEMP "keywordDirs_$((Get-Random)).psd1"
+        "@{ c = 'C' }" | Set-Content -Path $tmp -Encoding UTF8
+        Set-BKeywordDirsFile $tmp
+        Publish-KeywordDirs
+        Edit-KeywordDirs -Add @{ d = 'D' }
+        $global:KeywordDirs.Keys | Should -Contain 'd'
+        Remove-Item $tmp -Force
+    }
+}


### PR DESCRIPTION
## Summary
- add tests covering `Move-Files` and extension renaming
- add tests for rename helpers and sanitization logic
- add Pester tests for Set-Dir and helper utils
- register new test files in the launcher

## Testing
- `pwsh -NoLogo -File Scripts/Tests/Launcher-PesterTests.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507a6e9e1c83318821396520f40b5b