### PR TITLE
Add Pester tests for Packager

### DIFF
--- a/Scripts/Tests/Launcher-PesterTests.ps1
+++ b/Scripts/Tests/Launcher-PesterTests.ps1
@@ -31,6 +31,7 @@ $test08 = "$Script:PSRoot\Scripts\Tests\Test-GetOutlookItemType.Tests.ps1"
 $test09 = "$Script:PSRoot\Scripts\Tests\Test-DateTimeUtils.Tests.ps1"
 $test10 = "$Script:PSRoot\Scripts\Tests\Test-Logging.Tests.ps1"
 $test11 = "$Script:PSRoot\Scripts\Tests\Test-SelectFiles.Tests.ps1"
+$test12 = "$Script:PSRoot\Scripts\Tests\Test-Packager.Tests.ps1"
 
 
 # Optional breakpoints
@@ -40,7 +41,7 @@ $test11 = "$Script:PSRoot\Scripts\Tests\Test-SelectFiles.Tests.ps1"
 #Set-PSBreakpoint -Command '&'
 
 $conf = [PesterConfiguration]::Default
-$conf.Run.Path = @($test01, $test02, $test03, $test04, $test05, $test06, $test07, $test08, $test09, $test10, $test11)
+$conf.Run.Path = @($test01, $test02, $test03, $test04, $test05, $test06, $test07, $test08, $test09, $test10, $test11, $test12)
 #$conf.Run.Path = @($test01, $test02, $test03, $test04, $test05, $test06)
 
 $conf.Output.Verbosity = 'Detailed'

--- a/Scripts/Tests/Test-Packager.Tests.ps1
+++ b/Scripts/Tests/Test-Packager.Tests.ps1
@@ -1,0 +1,84 @@
+# Test-Packager.Tests.ps1
+
+# ===========================================================================================
+#region       Ensure PSRoot and Dot Source Core Globals
+# ===========================================================================================
+
+Describe "Packager.ps1" {
+    BeforeAll {
+        if (-not $Script:PSRoot) {
+            $Script:PSRoot = (Resolve-Path "$PSScriptRoot\..\..").Path
+            Write-Host "Set Script:PSRoot = $Script:PSRoot"
+        }
+        if (-not $Script:PSRoot) {
+            throw 'Script:PSRoot must be set by the entry-point script before using internal components.'
+        }
+
+        $Script:CliArgs = $args
+        . "$Script:PSRoot\Scripts\Initialize-CoreConfig.ps1"
+
+        $Script:scriptUnderTest = "$Script:PSRoot\Scripts\Packager\Packager.ps1"
+        . "$Script:scriptUnderTest"
+    }
+
+    Context "ConvertTo-ConfigHashtable" {
+        It "Converts PSCustomObject to hashtable" {
+            $input = [pscustomobject]@{
+                Name = "Test"
+                Nested = [pscustomobject]@{ Value = 42 }
+                Array = @(
+                    [pscustomobject]@{ Item = 1 },
+                    [pscustomobject]@{ Item = 2 }
+                )
+            }
+
+            $result = ConvertTo-ConfigHashtable -InputObject $input
+
+            $result | Should -BeOfType Hashtable
+            $result.Name | Should -Be "Test"
+            $result.Nested | Should -BeOfType Hashtable
+            $result.Nested.Value | Should -Be 42
+            $result.Array | Should -HaveCount 2
+            $result.Array[0].Item | Should -Be 1
+        }
+    }
+
+    Context "New-PackageConfigTemplate" {
+        It "Creates minimal package config file" {
+            $path = Join-Path $TestDrive 'template.json'
+
+            $template = New-PackageConfigTemplate -OutputPath $path -PackageName 'TestPkg' -Version '9.9.9' -Minimal
+
+            Test-Path $path | Should -BeTrue
+            $template.package.name | Should -Be 'TestPkg'
+            $template.package.version | Should -Be '9.9.9'
+
+            $json = Get-Content $path -Raw | ConvertFrom-Json
+            $json.package.name | Should -Be 'TestPkg'
+            $json.package.version | Should -Be '9.9.9'
+        }
+    }
+
+    Context "New-DirectoryStructure" {
+        It "Creates directories from config" {
+            $base = Join-Path $TestDrive 'out'
+            $config = @{
+                files = @(
+                    @{ destination = 'scripts' },
+                    @{ destination = 'docs' }
+                )
+                directories = @('tests')
+            }
+
+            $result = New-DirectoryStructure -BasePath $base -Config $config -Force
+            $result | Should -BeTrue
+            (Test-Path (Join-Path $base 'scripts')) | Should -BeTrue
+            (Test-Path (Join-Path $base 'docs')) | Should -BeTrue
+            (Test-Path (Join-Path $base 'tests')) | Should -BeTrue
+        }
+    }
+}
+
+# ===========================================================================================
+#endregion
+# ===========================================================================================


### PR DESCRIPTION
## Summary
- add Pester tests for core Packager functions
- include new test in launcher configuration

## Testing
- `powershell -NoLogo -NoProfile -Command "Invoke-Pester -Script Scripts/Tests/Test-Packager.Tests.ps1"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1a662cfc8331809307e002007ac4